### PR TITLE
detect codominant trees from dsm

### DIFF
--- a/forest3d/rasterization/__init__.py
+++ b/forest3d/rasterization/__init__.py
@@ -5,9 +5,10 @@ inputs and geospatial metadata.
 """
 
 from forest3d.rasterization.analytic_dsm import make_analytic_dsm
-from forest3d.rasterization.dsm import make_dsm
+from forest3d.rasterization.dsm import is_codominant_from_dsm, make_dsm
 
 __all__ = [
+    "is_codominant_from_dsm",
     "make_analytic_dsm",
     "make_dsm",
 ]

--- a/forest3d/rasterization/dsm.py
+++ b/forest3d/rasterization/dsm.py
@@ -1,11 +1,10 @@
-"""Digital surface model (DSM) rasterization (hot path).
+"""Digital surface model (DSM) rasterization and queries (hot path).
 
-This module provides JAX-friendly rasterization utilities for turning simulated
-point clouds (e.g., crown hull surface points) into a **DSM** raster.
+This module provides JAX-friendly utilities for building a DSM raster from
+simulated point clouds and for querying the resulting raster (e.g., codominance
+classification).
 
-Current definition
-------------------
-For this first pass, DSM is computed as: per-pixel maximum absolute `z` of all
+Current definition: DSM is computed as per-pixel maximum absolute z of all
 points that fall into the pixel (no ground subtraction).
 """
 
@@ -74,3 +73,52 @@ def make_dsm(
     fill_value = jnp.asarray(fill_value, dtype=raster.dtype)
     raster = jnp.where(jnp.isneginf(raster), fill_value, raster)
     return raster
+
+
+def is_codominant_from_dsm(
+    *,
+    dsm: ArrayLike,
+    i: ArrayLike,
+    j: ArrayLike,
+    z_apex: ArrayLike,
+    epsilon: float = 1e-5,
+) -> Array:
+    """Test whether each tree's apex is codominant on a merged DSM.
+
+    For each tree k, reads `dsm[i_k, j_k]` and compares to `z_apex_k`.
+    A tree is codominant when its apex is at or above the height of the DSM
+    at its apex cell.  The test is one-sided:
+
+        dsm[i_k, j_k] - z_apex_k <= epsilon
+
+    Trees overtopped by a neighbor crown (DSM exceeds apex by more than
+    epsilon) are not codominant.
+
+    Args:
+        dsm: Merged analytic DSM array, shape (ny, nx).
+        i: Per-tree row indices into the DSM, shape (B,). Typically from
+            `CoordinateSystem.xyz_to_ijk(..., grid=RASTER, integers=FLOOR)`.
+        j: Per-tree column indices into the DSM, shape (B,).
+        z_apex: Model apex elevation per tree, shape (B,).
+        epsilon: Absolute tolerance for the one-sided test (scalar, >= 0).
+            Defaults to 1e-5 to absorb floating-point rounding.
+
+    Returns:
+        Boolean array of shape (B,). True where
+        `dsm[i_k, j_k] - z_apex_k <= epsilon` and the index is in bounds.
+        Trees whose (i, j) falls outside the DSM shape are marked False.
+    """
+    dsm = jnp.asarray(dsm)
+    i = jnp.asarray(i)
+    j = jnp.asarray(j)
+    z_apex = jnp.asarray(z_apex)
+    ny, nx = dsm.shape
+
+    in_bounds = (i >= 0) & (i < ny) & (j >= 0) & (j < nx)
+
+    i_safe = jnp.where(in_bounds, i, 0)
+    j_safe = jnp.where(in_bounds, j, 0)
+    dsm_at_apex = dsm[i_safe, j_safe]
+
+    match = (dsm_at_apex - z_apex) <= epsilon
+    return in_bounds & match

--- a/forest3d/rasterization/tests/test_codominance.py
+++ b/forest3d/rasterization/tests/test_codominance.py
@@ -1,0 +1,110 @@
+import jax.numpy as jnp
+import pytest
+
+from forest3d.rasterization.dsm import is_codominant_from_dsm
+
+# A simple 3x3 DSM for most tests.
+#   row 0: [10, 12, 10]
+#   row 1: [10, 15, 10]
+#   row 2: [10, 10,  8]
+DSM_3x3 = jnp.array(
+    [
+        [10.0, 12.0, 10.0],
+        [10.0, 15.0, 10.0],
+        [10.0, 10.0, 8.0],
+    ]
+)
+
+
+def test_codominant_match():
+    """Tree apex z equals DSM value at its cell -> codominant."""
+    result = is_codominant_from_dsm(
+        dsm=DSM_3x3,
+        i=jnp.array([1]),
+        j=jnp.array([1]),
+        z_apex=jnp.array([15.0]),
+        epsilon=0.5,
+    )
+    assert result.shape == (1,)
+    assert result[0]
+
+
+def test_overtopped():
+    """Neighbor crown raises DSM above tree's apex z -> not codominant."""
+    result = is_codominant_from_dsm(
+        dsm=DSM_3x3,
+        i=jnp.array([1]),
+        j=jnp.array([1]),
+        z_apex=jnp.array([12.0]),
+        epsilon=0.5,
+    )
+    assert not result[0]
+
+
+def test_apex_above_dsm():
+    """Tree apex above DSM (e.g., lidar underestimation) -> still codominant."""
+    result = is_codominant_from_dsm(
+        dsm=DSM_3x3,
+        i=jnp.array([2]),
+        j=jnp.array([2]),
+        z_apex=jnp.array([20.0]),
+        epsilon=0.5,
+    )
+    assert result[0]
+
+
+@pytest.mark.parametrize(
+    "z_apex,expected",
+    [
+        (14.5, True),  # DSM is 0.5 above apex — exactly at epsilon boundary
+        (14.49, False),  # DSM is 0.51 above apex — just beyond epsilon
+        (15.5, True),  # apex 0.5 above DSM — always codominant (one-sided)
+        (100.0, True),  # apex far above DSM — still codominant
+    ],
+)
+def test_epsilon_boundary(z_apex, expected):
+    """Boundary behaviour around the epsilon tolerance (one-sided)."""
+    result = is_codominant_from_dsm(
+        dsm=DSM_3x3,
+        i=jnp.array([1]),
+        j=jnp.array([1]),
+        z_apex=jnp.array([z_apex]),
+        epsilon=0.5,
+    )
+    assert result[0] == expected
+
+
+@pytest.mark.parametrize(
+    "i,j",
+    [
+        (-1, 0),  # negative row
+        (0, -1),  # negative column
+        (3, 0),  # row >= ny
+        (0, 3),  # column >= nx
+        (3, 3),  # both out of bounds
+    ],
+)
+def test_out_of_bounds(i, j):
+    """Trees with OOB indices are marked not codominant."""
+    result = is_codominant_from_dsm(
+        dsm=DSM_3x3,
+        i=jnp.array([i]),
+        j=jnp.array([j]),
+        z_apex=jnp.array([10.0]),
+        epsilon=1.0,
+    )
+    assert not result[0]
+
+
+def test_batched_mixed():
+    """B=3 trees: codominant, overtopped, and OOB -> correct shape and values."""
+    result = is_codominant_from_dsm(
+        dsm=DSM_3x3,
+        i=jnp.array([0, 1, 5]),
+        j=jnp.array([0, 1, 0]),
+        z_apex=jnp.array([10.0, 12.0, 10.0]),
+        epsilon=0.5,
+    )
+    assert result.shape == (3,)
+    expected = jnp.array([True, False, False])
+    assert jnp.array_equal(result, expected)


### PR DESCRIPTION
## Summary
Adds a helper function to detect whether a tree is considered codominant based on whether it's apex is at or above a digital surface model. trees outside the the bounds of the dsm are treated as non-codominant.

## Test Plan
unit tests added to check for trees at, above, and below dsm.